### PR TITLE
test: check additional fields are retained and can be removed

### DIFF
--- a/src/projects.ts
+++ b/src/projects.ts
@@ -63,8 +63,11 @@ export type Project = {
     address_city: null | string,
     address_state: null | string,
 
-    /** Additional fields can be configured in Company Settings -> Workflow Settings */
-    additional: null | Record<string, string>,
+    /** 
+     * Additional fields can be configured in Company Settings -> Workflow Settings
+     * Record null values are removed and will be undefined.
+     */
+    additional: null | Record<string, string | number>,
 
     /**
      * Supported ISO 3166-1 alpha-2 country codes
@@ -104,7 +107,11 @@ type ProjectCreationData = {
 
     workflow_assignments?: ProjectWorkflowAssignments;
 
-    additional?: Record<string, string>;
+    /**
+     * Additional fields can be configured in Company Settings -> Workflow Settings
+     * Provide null to remove the field
+     */
+    additional?: Record<string, string | number | null>;
 };
 
 /**

--- a/tests/project-integration.spec.ts
+++ b/tests/project-integration.spec.ts
@@ -158,14 +158,17 @@ if (process.env.DATANEST_API_KEY && process.env.DATANEST_API_SECRET && process.e
         expect(createWith.project.additional?.my_additional_field).equals('test');
         expect(createWith.project.additional?.my_reference).equals('ref123');
 
-        const updatedProject = await patchProject(client, createdWithout.project.uuid, {
+        const updatedProject = await patchProject(client, createWith.project.uuid, {
             additional: {
                 added_after_creation: 'yes',
+                my_reference: null,
             },
         });
 
         expect(updatedProject.project.additional).is.an('object');
-        expect(updatedProject.project.additional?.added_after_creation).equals('yes');
+        expect(updatedProject.project.additional?.added_after_creation).equals('yes', 'New field should be added');
+        expect(updatedProject.project.additional?.my_additional_field).equals('test', 'Old field should be retained');
+        expect(updatedProject.project.additional?.my_reference).equals(undefined, 'Fields are completely removed with null');
     });
 
     afterAll(async () => {

--- a/tests/project-integration.spec.ts
+++ b/tests/project-integration.spec.ts
@@ -147,7 +147,7 @@ if (process.env.DATANEST_API_KEY && process.env.DATANEST_API_SECRET && process.e
                 address_country: 'NZ',
                 additional: {
                     my_additional_field: 'test',
-                    my_reference: 'ref123',
+                    my_reference: 123,
                 },
             }),
         ]);
@@ -156,7 +156,7 @@ if (process.env.DATANEST_API_KEY && process.env.DATANEST_API_SECRET && process.e
         expect(createdWithout.project.additional).equals(null);
         expect(createWith.project.additional).is.an('object');
         expect(createWith.project.additional?.my_additional_field).equals('test');
-        expect(createWith.project.additional?.my_reference).equals('ref123');
+        expect(createWith.project.additional?.my_reference).equals(123);
 
         const updatedProject = await patchProject(client, createWith.project.uuid, {
             additional: {


### PR DESCRIPTION
Updated test for additional field edge cases
- Patching additional fields does not remove previous fields
- Providing null will remove the additional field completely, including the record key.
- Supporting number type additional fields

![image](https://github.com/user-attachments/assets/1c467d82-0b73-4486-ba58-24921faf834d)
