### PR TITLE
feat: encourage new app bundle endpoint and terminology

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datanest-earth/nodejs-client",
-  "version": "0.9.2",
+  "version": "0.10.0",
   "description": "Datanest API Client to easily create signed requests",
   "main": "dist/index.cjs",
   "module": "dist/index.js",


### PR DESCRIPTION
## Changes

- feat: added new App Bundle sharing endpoints
- deprecated: old Share Group sharing endpoints, full backwards compatibility

## Motivation

Maintain consistency between Datanest's UI terminology and the corresponding API endpoints, new terminology is encouraged but backwards compatibility is important.

## Testing

![image](https://github.com/user-attachments/assets/95ccabfb-e1f2-4c8e-bb59-1c2fb486aed8)
