### PR TITLE
fix: webhook signature verification & tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datanest-earth/nodejs-client",
-  "version": "0.9.2",
+  "version": "0.9.3",
   "description": "Datanest API Client to easily create signed requests",
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import * as integrations from './integrations';
 import * as teams from './teams';
 import * as users from './users';
 import * as files from './files';
+import * as webhook from './webhook';
 
 /**
  * @deprecated Use `users` namespace instead
@@ -24,6 +25,7 @@ export {
     user,
     users,
     files,
+    webhook,
 }
 
 export default class DatanestClient {


### PR DESCRIPTION
## Changes

- fix: dont manipulate signature content
- fix: made `authenticateWebhook` useful as it no longer consumes the Request.body reader
- chore: exported `authenticateWebhook` to use outside of this package
- test: improve webhook tests

## Testing
![image](https://github.com/user-attachments/assets/2043e0bd-4acb-4ede-873b-d0d8168984e7)
